### PR TITLE
fix(nx): Install terser with app-web

### DIFF
--- a/packages/nx/src/generators/app-web/app-web.ts
+++ b/packages/nx/src/generators/app-web/app-web.ts
@@ -62,7 +62,7 @@ export default async function generate(tree: Tree, options: Schema) {
   addDependenciesToPackageJson(
     tree,
     {},
-    getDependencyVersions(['@eternagame/nx-spawn'])
+    getDependencyVersions(['@eternagame/nx-spawn', 'terser'])
   );
 
   const projectPackageJsonPath = path.join(

--- a/packages/nx/src/utils/dependencies.ts
+++ b/packages/nx/src/utils/dependencies.ts
@@ -51,6 +51,7 @@ const VERSIONS = {
   jest: '^27.5.0',
   '@types/jest': '^27.4.0',
   'ts-jest': '^27.1.3',
+  terser: '^5.14.2',
 } as const;
 
 export default function getDependencyVersions(


### PR DESCRIPTION
vite@3 has terser as an optional peer dependency, but as long as we want to use plugin-legacy, it forces us to use terser as our minifier instead of esbuild (as apparently esbuild is not "legacy compatible")