### PR TITLE
feat(nx): Rename lint-workspace to lint-project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build
         run: npx nx affected --target=build --parallel=3
       - name: Lint Workspace
-        run: npm run lint-workspace
+        run: npm run lint-project
       - name: Lint Projects
         run: npx nx affected --target=lint --parallel=3
       - name: Format Check

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -14,7 +14,7 @@ module.exports = (allStagedFiles) => {
   return [
     // Lint any files which are not part of an app (eslint will handle ignoring any staged files
     // which are not part of an app via its ignore rules)
-    `npm run _lint-workspace ${codeFiles} -- --fix`,
+    `npm run _lint-project ${codeFiles} -- --fix`,
     // Lint any packages affected by uncommitted changes
     'nx affected --target=lint --uncommitted --fix',
     // Format any packages (or files not in a package) affected by uncommitted changes

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "license": "BSD-3-Clause",
   "private": true,
   "scripts": {
-    "_lint-workspace": "npx eslint --ignore-path .gitignore --ignore-pattern packages/",
-    "lint-workspace": "npm run _lint-workspace .",
+    "_lint-project": "npx eslint --ignore-path .gitignore --ignore-pattern packages/",
+    "lint-project": "npm run _lint-project .",
     "prepare": "husky install"
   },
   "devDependencies": {

--- a/packages/nx/src/generators/preset/files/.github/workflows/ci.yml
+++ b/packages/nx/src/generators/preset/files/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build
         run: npx nx affected --target=build --parallel=3
       - name: Lint Workspace
-        run: npm run lint-workspace
+        run: npm run lint-project
       - name: Lint Projects
         run: npx nx affected --target=lint --parallel=3
       - name: Format Check

--- a/packages/nx/src/generators/preset/files/lint-staged.config.js__tmpl__
+++ b/packages/nx/src/generators/preset/files/lint-staged.config.js__tmpl__
@@ -14,7 +14,7 @@ module.exports = (allStagedFiles) => {
   return [
     // Lint any files which are not part of an app (eslint will handle ignoring any staged files
     // which are not part of an app via its ignore rules)
-    `npm run _lint-workspace ${codeFiles} -- --fix`,
+    `npm run _lint-project ${codeFiles} -- --fix`,
     // Lint any packages affected by uncommitted changes
     'nx affected --target=lint --uncommitted --fix',
     // Format any packages (or files not in a package) affected by uncommitted changes

--- a/packages/nx/src/generators/preset/files/package.json__tmpl__
+++ b/packages/nx/src/generators/preset/files/package.json__tmpl__
@@ -4,8 +4,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "lint-workspace": "npm run _lint-workspace .",
-    "_lint-workspace": "npx eslint --ignore-path .gitignore --ignore-pattern packages/",
+    "lint-project": "npm run _lint-project .",
+    "_lint-project": "npx eslint --ignore-path .gitignore --ignore-pattern packages/",
     "prepare": "husky install"
   },
   "devDependencies": {},


### PR DESCRIPTION
If we're using the terms of npm workspaces, the subpackages are technically the workspaces, so the terminology was incorrect.