### PR TITLE
fix(nx-plugin): Don't run format files in generators

### DIFF
--- a/packages/nx-plugin/src/generators/app-node/index.ts
+++ b/packages/nx-plugin/src/generators/app-node/index.ts
@@ -1,7 +1,6 @@
 import * as path from 'path';
 import {
   addDependenciesToPackageJson,
-  formatFiles,
   generateFiles,
   getWorkspaceLayout,
   installPackagesTask,
@@ -78,8 +77,6 @@ export default async function generate(tree: Tree, options: Schema) {
     return json;
   });
   /* eslint-enable no-param-reassign */
-
-  await formatFiles(tree);
 
   return () => {
     finalizeTsNode();

--- a/packages/nx-plugin/src/generators/app-web/index.ts
+++ b/packages/nx-plugin/src/generators/app-web/index.ts
@@ -1,7 +1,6 @@
 import * as path from 'path';
 import {
   addDependenciesToPackageJson,
-  formatFiles,
   generateFiles,
   getWorkspaceLayout,
   installPackagesTask,
@@ -80,8 +79,6 @@ export default async function generate(tree: Tree, options: Schema) {
     return json;
   });
   /* eslint-enable no-param-reassign */
-
-  await formatFiles(tree);
 
   return () => {
     finalizeTsNode();

--- a/packages/nx-plugin/src/generators/package/index.ts
+++ b/packages/nx-plugin/src/generators/package/index.ts
@@ -1,5 +1,4 @@
 import {
-  formatFiles,
   generateFiles,
   getWorkspaceLayout,
   joinPathFragments,
@@ -57,5 +56,4 @@ export default async function generate(tree: Tree, options: Schema) {
   const normalizedOptions = normalizeOptions(tree, options);
   addFiles(tree, normalizedOptions);
   updatePackageLicense(tree, normalizedOptions.projectRoot);
-  await formatFiles(tree);
 }

--- a/packages/nx-plugin/src/generators/preset/index.ts
+++ b/packages/nx-plugin/src/generators/preset/index.ts
@@ -1,6 +1,5 @@
 import path from 'path';
 import {
-  formatFiles,
   generateFiles,
   installPackagesTask,
   addDependenciesToPackageJson,
@@ -98,7 +97,6 @@ export default async function generate(tree: Tree, options: Schema) {
       normalizedOptions.copyrightHolder
       || (normalizedOptions.eternaDefaults ? 'Eterna Commons' : ''),
   });
-  await formatFiles(tree);
   return () => {
     finalizeGenerateLicense();
     installPackagesTask(tree);

--- a/packages/nx-plugin/src/generators/ts-iso/index.ts
+++ b/packages/nx-plugin/src/generators/ts-iso/index.ts
@@ -1,7 +1,6 @@
 import * as path from 'path';
 import {
   addDependenciesToPackageJson,
-  formatFiles,
   generateFiles,
   getWorkspaceLayout,
   installPackagesTask,
@@ -102,7 +101,6 @@ export default async function generate(tree: Tree, options: Schema) {
   await generatePackage(tree, options);
   addFiles(tree, normalizedOptions);
   updatePackageJson(tree, normalizedOptions);
-  await formatFiles(tree);
 
   return () => {
     installPackagesTask(tree);

--- a/packages/nx-plugin/src/generators/ts-node/index.ts
+++ b/packages/nx-plugin/src/generators/ts-node/index.ts
@@ -1,6 +1,5 @@
 import * as path from 'path';
 import {
-  formatFiles,
   generateFiles,
   getWorkspaceLayout,
   joinPathFragments,
@@ -74,8 +73,6 @@ export default async function generate(tree: Tree, options: Schema) {
     },
   );
   /* eslint-enable no-param-reassign */
-
-  await formatFiles(tree);
 
   return () => {
     finalizeIso();

--- a/packages/nx-plugin/src/generators/ts-web/index.ts
+++ b/packages/nx-plugin/src/generators/ts-web/index.ts
@@ -1,6 +1,5 @@
 import * as path from 'path';
 import {
-  formatFiles,
   generateFiles,
   getWorkspaceLayout,
   joinPathFragments,
@@ -74,8 +73,6 @@ export default async function generate(tree: Tree, options: Schema) {
     },
   );
   /* eslint-enable no-param-reassign */
-
-  await formatFiles(tree);
 
   return () => {
     finalizeIso();


### PR DESCRIPTION
We're not using prettier any more, so don't run prettier in our generators