### PR TITLE
chore(lint-staged-utils): Make vite-utils an implicit dependency of lint-staged-utils

### DIFF
--- a/packages/lint-staged-utils/package.json
+++ b/packages/lint-staged-utils/package.json
@@ -21,5 +21,10 @@
   ],
   "dependencies": {
     "micromatch": "^4.0.5"
+  },
+  "nx": {
+    "implicitDependencies": [
+      "vite-utils"
+    ]
   }
 }


### PR DESCRIPTION
lint-staged-utils relies on vite-utils to build, so vite-utils needs to be built first