### PR TITLE
fix(nx-plugin): Provide registry URL for canary + update actions versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,11 @@ jobs:
     needs: release-please
     if: needs.release-please.outputs.releases_created != 'true'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: release-please--branches--main
           fetch-depth: 2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
       - name: Update package-lock.json
@@ -71,9 +71,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
+          registry-url: 'https://registry.npmjs.org'
       - name: Use the node_modules cache if available
         uses: actions/cache@v3
         with:

--- a/packages/nx-plugin/src/generators/release/files/.github/workflows/release.yml__tmpl__
+++ b/packages/nx-plugin/src/generators/release/files/.github/workflows/release.yml__tmpl__
@@ -23,11 +23,11 @@ jobs:
     needs: release-please
     if: needs.release-please.outputs.releases_created != 'true'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: release-please--branches--main
           fetch-depth: 2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
       - name: Update package-lock.json
@@ -72,9 +72,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
+          registry-url: 'https://registry.npmjs.org'
       - name: Use the node_modules cache if available
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
- The reason our canary publishes failed is because I neglected to set the registry URL per https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry
- The actions being used in parts of the release workflow were outdated - that's now fixed