### PR TITLE
fix(nx-plugin): Correct nx output paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,10 +83,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-${{ steps.versions.outputs.node_version }}-
       - run: npm ci
-      # Lerna publish can run into a race condition where multiple builds are initiated at the same time which
-      # causes vite-utils to be removed as soon as it's built. Build it ahead of time so that we can ensure
-      # it's cached
-      - run: npx nx build vite-utils
       - run: npx lerna publish --yes
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/packages/nx-plugin/preset.json
+++ b/packages/nx-plugin/preset.json
@@ -35,7 +35,7 @@
     "build": {
       "inputs": ["default", "^default"],
       "dependsOn": ["^build"],
-      "outputs": ["./dist"]
+      "outputs": ["{projectRoot}/dist"]
     },
     "lint": {
       "inputs": ["default", "^default", "test", "{workspaceRoot}/.eslintrc.js"],
@@ -63,7 +63,7 @@
     },
     "build:watch": {
       "dependsOn": ["^build:watch"],
-      "outputs": ["./dist"]
+      "outputs": ["{projectRoot}/dist"]
     },
     "_dev": {
       "dependsOn": ["build:watch"]


### PR DESCRIPTION
This should be the correct fix for our canary CI failures rather than #171 - it appears something in Nx's path resolution changed such that when we run `nx build` within a package directory, it resolves the outputs of other packages relative to that directory rather than the root