### PR TITLE
fix(nx-plugin): Publish concurrency fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,14 +43,14 @@ jobs:
       - name: Build lint-staged-utils
         run: npx nx build lint-staged-utils
       - name: Build
-        run: npx nx affected --target=build --parallel=3
+        run: npx nx affected --target=build
       - name: Lint Core Files
         run: npm run lint-core
       - name: Lint Packages
-        run: npx nx affected --target=lint --parallel=3
+        run: npx nx affected --target=lint
       - name: Nx Integrity Check
         run: npx nx workspace-lint
       - name: Unit Tests
-        run: npx nx affected --target=test --parallel=3
+        run: npx nx affected --target=test
       - name: End to End Tests
         run: npx nx affected --target e2e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-${{ steps.versions.outputs.node_version }}-
       - run: npm ci
+      - run: npm run-many --target build
       - run: npm publish -ws
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
@@ -83,6 +84,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-${{ steps.versions.outputs.node_version }}-
       - run: npm ci
+      - run: npm run-many --target build
       - run: npx lerna publish --yes
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/packages/bootstrap/package.json
+++ b/packages/bootstrap/package.json
@@ -13,7 +13,6 @@
   },
   "scripts": {
     "start": "node dist/index.js",
-    "prepublishOnly": "nx build",
     "build": "vite build",
     "postbuild": "shx chmod +x ./dist/index.js && npm install --save=false",
     "lint": "eslint ."

--- a/packages/cypress-utils/package.json
+++ b/packages/cypress-utils/package.json
@@ -12,7 +12,6 @@
   },
   "license": "BSD-3-Clause",
   "scripts": {
-    "prepublishOnly": "nx build",
     "build": "vite build",
     "build:watch": "vite build --mode development",
     "lint": "eslint ."

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -12,7 +12,6 @@
     "access": "public"
   },
   "scripts": {
-    "prepublishOnly": "nx build",
     "build": "vite build",
     "lint": "eslint ."
   },

--- a/packages/lint-staged-utils/package.json
+++ b/packages/lint-staged-utils/package.json
@@ -12,7 +12,6 @@
     "access": "public"
   },
   "scripts": {
-    "prepublishOnly": "nx build",
     "build": "vite build",
     "build:watch": "vite build --mode development",
     "lint": "eslint ."

--- a/packages/nx-plugin/package.json
+++ b/packages/nx-plugin/package.json
@@ -12,7 +12,6 @@
     "access": "public"
   },
   "scripts": {
-    "prepublishOnly": "nx build",
     "build": "vite build",
     "lint": "eslint ."
   },

--- a/packages/nx-plugin/src/generators/package/base/index.ts
+++ b/packages/nx-plugin/src/generators/package/base/index.ts
@@ -147,7 +147,6 @@ function setupPublishing(tree: Tree, options: NormalizedSchema) {
 
       json['publishConfig'] = { access: options.publish };
       json['files'] = ['dist'];
-      scripts['prepublishOnly'] = 'nx build';
 
       return json;
     });

--- a/packages/nx-plugin/src/generators/preset/files/.github/workflows/ci.yml
+++ b/packages/nx-plugin/src/generators/preset/files/.github/workflows/ci.yml
@@ -36,14 +36,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Build
-        run: npx nx affected --target=build --parallel=3
+        run: npx nx affected --target=build
       - name: Lint Core Files
         run: npm run lint-core
       - name: Lint Packages
-        run: npx nx affected --target=lint --parallel=3
+        run: npx nx affected --target=lint
       - name: Nx Integrity Check
         run: npx nx workspace-lint
       - name: Unit Tests
-        run: npx nx affected --target=test --parallel=3
+        run: npx nx affected --target=test
       - name: End to End Tests
         run: npx nx affected --target e2e

--- a/packages/nx-plugin/src/generators/release/repo/files/.github/workflows/release.yml__tmpl__
+++ b/packages/nx-plugin/src/generators/release/repo/files/.github/workflows/release.yml__tmpl__
@@ -59,6 +59,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-${{ steps.versions.outputs.node_version }}-
       - run: npm ci
+      - run: npm run-many --target build
       - run: npm publish -ws
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
@@ -86,6 +87,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-${{ steps.versions.outputs.node_version }}-
       - run: npm ci
+      - run: npm run-many --target build
       - run: npx lerna publish --yes
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/packages/nx-spawn/package.json
+++ b/packages/nx-spawn/package.json
@@ -13,7 +13,6 @@
   },
   "scripts": {
     "start": "node dist/index.js",
-    "prepublishOnly": "nx build",
     "build": "vite build",
     "postbuild": "shx chmod +x ./dist/index.js && npm install --save=false",
     "lint": "eslint ."

--- a/packages/vite-utils/package.json
+++ b/packages/vite-utils/package.json
@@ -13,7 +13,6 @@
     "access": "public"
   },
   "scripts": {
-    "prepublishOnly": "nx build",
     "build": "vite build",
     "lint": "eslint ."
   },


### PR DESCRIPTION
* Again, hoping to fix canary builds. Instead of relying on prepublishOnly, since apparently nx is resolving relative paths differently in some situation (#172 didn't help), we'll just build everything ahead of time
* The nx affected commands being run in CI are already default parallel 3, so stick with the defaults