### PR TITLE
fix(bootstrap,eslint-plugin,nx-plugin): Consolidated fixes from runthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,23 @@ Run `npx nx lint <package-name> --fix` to run linting with automatic fixes
 <!-- End managed by @eternagame/nx-plugin - commands/lint -->
 
 <!-- Managed by @eternagame/nx-plugin - commands/test -->
-### Unit Tests
+### Testing
 
-Run `npx nx test <package-name>` to execute the unit tests for a package via [Vitest](https://vitest.dev/).
+Run `npx nx test <package-name>` to execute unit/component tests for a package via [Vitest](https://vitest.dev/)
+or [Cypress](https://www.cypress.io/) (depending on which is configured for the package).
 
-Run `npx nx affected:test` to execute the unit tests for all packages affected by a code change.
+Run `npx nx test:watch <package-name>` to execute unit/component tests for a package in watch mode (Vitest only).
+
+Run `npx nx test:cov <package-name>` to execute unit/component tests and report code coverage for a
+package in watch mode (Vitest only).
+
+Run `npx nx test:ui <package-name>` to execute unit/component tests for a package using the UI-based test runner (Cypress only).
+
+Run `npx nx affected:test` to execute unit/component tests for all packages affected by a code change.
+
+Run `npx nx e2e <package-name>` to execute end to end tests in a package, if configured.
+
+Run `npx nx affected:e2e` to execute all end to end tests in packages affected by a code change.
 <!-- End managed by @eternagame/nx-plugin - commands/test -->
 
 <!-- Managed by @eternagame/nx-plugin - commands/generate -->

--- a/packages/bootstrap/index.ts
+++ b/packages/bootstrap/index.ts
@@ -40,6 +40,7 @@ async function main() {
 
   const options = [
     args.name,
+    ...(args.eterna ? ['--eternaDefaults'] : []),
     ...(args.npmScope ? ['--npmScope', args.npmScope] : []),
   ];
   await spawn('npx', ['nx', 'g', '@eternagame/nx-plugin:preset', ...options], {

--- a/packages/eslint-plugin/src/configs/base/vue.ts
+++ b/packages/eslint-plugin/src/configs/base/vue.ts
@@ -1,7 +1,6 @@
 export default {
   parser: require.resolve('vue-eslint-parser'),
   parserOptions: {
-    extraFileExtensions: ['.vue'],
     parser: {
       // We set the main parser above, but we need to tell eslint what to use for the
       // internal js/ts parts of the SFC

--- a/packages/eslint-plugin/src/configs/javascript.ts
+++ b/packages/eslint-plugin/src/configs/javascript.ts
@@ -13,9 +13,9 @@ export default {
       ],
     },
     {
-      files: ['{jest,vitest,vite,cypress}.config.{js,mjs,cjs}'],
+      files: ['{jest,vitest,vite,cypress}.config.{js,mjs,cjs}', 'cypress/**/*.{js,mjs,cjs}'],
       rules: {
-        // Allow our configs to import dev dependencies
+        // Allow our dev tooling to import dev dependencies
         ...noExtraneousDependencies(true, false),
       },
     },

--- a/packages/eslint-plugin/src/configs/typescript.ts
+++ b/packages/eslint-plugin/src/configs/typescript.ts
@@ -38,6 +38,13 @@ export default {
       },
     },
     {
+      files: ['cypress/**/*.{js,mjs,cjs}'],
+      rules: {
+        // Allow our dev tooling to import dev dependencies
+        ...noExtraneousDependencies(true, false),
+      },
+    },
+    {
       files: ['index.{ts,mts,cts}'],
       rules: {
         // Index files are useful for exposing public APIs which may initially only have

--- a/packages/eslint-plugin/src/configs/typescript.ts
+++ b/packages/eslint-plugin/src/configs/typescript.ts
@@ -38,7 +38,7 @@ export default {
       },
     },
     {
-      files: ['cypress/**/*.{js,mjs,cjs}'],
+      files: ['cypress/**/*.{ts,mts,cts}'],
       rules: {
         // Allow our dev tooling to import dev dependencies
         ...noExtraneousDependencies(true, false),

--- a/packages/eslint-plugin/src/configs/vue3-typescript.ts
+++ b/packages/eslint-plugin/src/configs/vue3-typescript.ts
@@ -1,5 +1,17 @@
 export default {
   extends: require.resolve('./typescript'),
+  parserOptions: {
+    // This has to be done here rather than in the base vue config because it actually
+    // needs to be provided to @typescript-eslint/parser for *any* file type it handles.
+    // This seemingly has to do with how it "caches" loaded typescript projects.
+    // E.g., if we have cypress/support/component.ts and src/App.vue (and, presumably,
+    // both can be found within a single tsconfig), the ts file will be loaded first so
+    // the typescript project will be created *without* the extra extension, and when it
+    // encounters the vue file, it will just reuse that typescript project instead of creating
+    // a new one with the extra extension, and so it will complain that it can't find the .vue in
+    // any tsconfig.
+    extraFileExtensions: ['.vue'],
+  },
   overrides: [
     {
       files: ['*.vue'],

--- a/packages/nx-plugin/package.json
+++ b/packages/nx-plugin/package.json
@@ -33,7 +33,6 @@
     "./*.json": "./*.json"
   },
   "generators": "./generators.json",
-  "executors": "./executors.json",
   "dependencies": {
     "@nrwl/devkit": "^14.6.5"
   },

--- a/packages/nx-plugin/preset.json
+++ b/packages/nx-plugin/preset.json
@@ -39,7 +39,7 @@
     },
     "lint": {
       "inputs": ["default", "^default", "test", "{workspaceRoot}/.eslintrc.js"],
-      "dependsOn": ["build"]
+      "dependsOn": ["^build"]
     },
     "test": {
       "inputs": ["default", "^default", "test"],

--- a/packages/nx-plugin/src/generators/package/cypress/ct/files/cypress/support/commands.ts__tmpl__
+++ b/packages/nx-plugin/src/generators/package/cypress/ct/files/cypress/support/commands.ts__tmpl__
@@ -30,7 +30,11 @@
 //       login(email: string, password: string): Chainable<void>
 //       drag(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
 //       dismiss(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
-//       visit(originalFn: CommandOriginalFn, url: string, options: Partial<VisitOptions>): Chainable<Element>
+//       visit(
+//        originalFn: CommandOriginalFn,
+//        url: string,
+//        options: Partial<VisitOptions>
+//      ): Chainable<Element>
 //     }
 //   }
 // }

--- a/packages/nx-plugin/src/generators/package/cypress/ct/files/cypress/support/component.ts__tmpl__
+++ b/packages/nx-plugin/src/generators/package/cypress/ct/files/cypress/support/component.ts__tmpl__
@@ -14,7 +14,7 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
-import './commands'
+import './commands';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/packages/nx-plugin/src/generators/package/cypress/ct/files/cypress/support/component.ts__tmpl__
+++ b/packages/nx-plugin/src/generators/package/cypress/ct/files/cypress/support/component.ts__tmpl__
@@ -22,6 +22,8 @@ import './commands';
 // Import global styles
 import '@/assets/style.css';
 
+// eslint-plugin-import has a false positive here
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { mount } from 'cypress/vue';
 
 // Augment the Cypress namespace to include type definitions for

--- a/packages/nx-plugin/src/generators/package/cypress/ct/index.ts
+++ b/packages/nx-plugin/src/generators/package/cypress/ct/index.ts
@@ -81,7 +81,6 @@ export default async function generate(tree: Tree, options: Schema) {
       tree,
       [
         '@eternagame/cypress-utils',
-        '@cypress/vue',
         'cypress',
       ],
     );

--- a/packages/nx-plugin/src/generators/package/cypress/ct/index.ts
+++ b/packages/nx-plugin/src/generators/package/cypress/ct/index.ts
@@ -81,6 +81,7 @@ export default async function generate(tree: Tree, options: Schema) {
       tree,
       [
         '@eternagame/cypress-utils',
+        '@cypress/vue',
         'cypress',
       ],
     );

--- a/packages/nx-plugin/src/generators/package/vue/app/files/src/components/HelloWorld.vue__tmpl__
+++ b/packages/nx-plugin/src/generators/package/vue/app/files/src/components/HelloWorld.vue__tmpl__
@@ -13,7 +13,5 @@ defineProps({
   },
 });
 
-const emit = defineEmits<{
-  (e: 'buttonClicked'): void
-}>();
+const emit = defineEmits<(e: 'buttonClicked') => void>();
 </script>

--- a/packages/nx-plugin/src/generators/package/vue/lib/files/src/components/HelloWorld.vue__tmpl__
+++ b/packages/nx-plugin/src/generators/package/vue/lib/files/src/components/HelloWorld.vue__tmpl__
@@ -13,5 +13,5 @@ defineProps({
   },
 });
 
-const emit = defineEmits<{ (e: 'buttonClicked'): void }>();
+const emit = defineEmits<(e: 'buttonClicked') => void>();
 </script>

--- a/packages/nx-plugin/src/generators/preset/files/.eslintrc.js__tmpl__
+++ b/packages/nx-plugin/src/generators/preset/files/.eslintrc.js__tmpl__
@@ -1,10 +1,13 @@
 const fs = require('fs');
+const { join } = require('path');
 
 module.exports = {
   root: true,
-  ignorePatterns: fs.readFileSync("./.gitignore", "utf8").split("\n"),
+  ignorePatterns: fs
+    .readFileSync(join(__dirname, './.gitignore'), 'utf8')
+    .split('\n'),
   extends: [
     'plugin:@eternagame/typescript',
     'plugin:@eternagame/nx-typescript',
-  ]
-}
+  ],
+};

--- a/packages/nx-plugin/src/generators/preset/files/.vscode/settings.json
+++ b/packages/nx-plugin/src/generators/preset/files/.vscode/settings.json
@@ -11,5 +11,5 @@
   "editor.codeActionsOnSave": [
     "source.fixAll.eslint"
   ],
-  "eslint.workingDirectories": [{"mode": "auto"}],
+  "eslint.workingDirectories": [{"mode": "auto"}]
 }

--- a/packages/nx-plugin/src/generators/preset/files/README.md
+++ b/packages/nx-plugin/src/generators/preset/files/README.md
@@ -49,11 +49,23 @@ Run `npx nx lint <package-name> --fix` to run linting with automatic fixes
 <!-- End managed by @eternagame/nx-plugin - commands/lint -->
 
 <!-- Managed by @eternagame/nx-plugin - commands/test -->
-### Unit Tests
+### Testing
 
-Run `npx nx test <package-name>` to execute the unit tests for a package via [Vitest](https://vitest.dev/).
+Run `npx nx test <package-name>` to execute unit/component tests for a package via [Vitest](https://vitest.dev/)
+or [Cypress](https://www.cypress.io/) (depending on which is configured for the package).
 
-Run `npx nx affected:test` to execute the unit tests for all packages affected by a code change.
+Run `npx nx test:watch <package-name>` to execute unit/component tests for a package in watch mode (Vitest only).
+
+Run `npx nx test:cov <package-name>` to execute unit/component tests and report code coverage for a
+package in watch mode (Vitest only).
+
+Run `npx nx test:ui <package-name>` to execute unit/component tests for a package using the UI-based test runner (Cypress only).
+
+Run `npx nx affected:test` to execute unit/component tests for all packages affected by a code change.
+
+Run `npx nx e2e <package-name>` to execute end to end tests in a package, if configured.
+
+Run `npx nx affected:e2e` to execute all end to end tests in packages affected by a code change.
 <!-- End managed by @eternagame/nx-plugin - commands/test -->
 
 <!-- Managed by @eternagame/nx-plugin - commands/generate -->

--- a/packages/nx-plugin/src/generators/preset/files/package.json__tmpl__
+++ b/packages/nx-plugin/src/generators/preset/files/package.json__tmpl__
@@ -3,7 +3,6 @@
   "description": "<%= description %>",
   "version": "0.0.0",
   "private": true,
-  "type": "module",
   "scripts": {
     "lint-core": "eslint --ignore-pattern packages/ .",
     "prepare": "husky install"

--- a/packages/nx-plugin/src/generators/preset/index.ts
+++ b/packages/nx-plugin/src/generators/preset/index.ts
@@ -8,7 +8,7 @@ import {
 import { setGeneratorDefaults } from '@/utils/wrap-generator';
 import generateLicense from '../license/repo';
 import generateRelease from '../release/repo';
-import { installDevDependencies } from '@/utils/dependencies';
+import { installDevDependencies, NX_PLUGIN_VERSION } from '@/utils/dependencies';
 
 const ETERNA_NPM_SCOPE = 'eternagame';
 const ETERNA_COPYRIGHT_HOLDER = 'Eterna Commons';
@@ -93,7 +93,7 @@ export default async function generate(tree: Tree, options: Schema) {
     await finalizeGenerateLicense();
     await finalizeGenerateRelease();
     installDevDependencies(tree, [
-      '@eternagame/nx-plugin',
+      `@eternagame/nx-plugin@${NX_PLUGIN_VERSION}`,
       '@eternagame/eslint-plugin',
       '@eternagame/lint-staged-utils',
       'nx',

--- a/packages/nx-plugin/src/generators/preset/index.ts
+++ b/packages/nx-plugin/src/generators/preset/index.ts
@@ -95,6 +95,7 @@ export default async function generate(tree: Tree, options: Schema) {
     installDevDependencies(tree, [
       '@eternagame/nx-plugin',
       '@eternagame/eslint-plugin',
+      '@eternagame/lint-staged-utils',
       'nx',
       'eslint',
       'eslint-config-airbnb-base',

--- a/packages/nx-plugin/src/generators/preset/schema.json
+++ b/packages/nx-plugin/src/generators/preset/schema.json
@@ -31,7 +31,7 @@
       "description": "How packages should be configured for publishing by default",
       "enum": ["private", "restricted", "public"],
       "x-prompt": {
-        "message": "How should the package be configured for publishing",
+        "message": "How should packages should be configured for publishing by default?",
         "type": "list",
         "items": [
           { "value": "private", "label": "Mark package as not publishable" },
@@ -58,7 +58,7 @@
     "license": {
       "type": "string",
       "description": "Repository license",
-      "enum": ["MIT", "BSD3", "Custom", "None"],
+      "enum": ["MIT", "BSD3", "EternaNoncommercial", "Custom", "None"],
       "x-prompt": {
         "message": "Which license would you like to use?",
         "type": "list",

--- a/packages/nx-plugin/src/utils/dependencies.ts
+++ b/packages/nx-plugin/src/utils/dependencies.ts
@@ -2,7 +2,23 @@ import {
   detectPackageManager, getPackageManagerCommand, joinPathFragments, readJson, Tree,
 } from '@nrwl/devkit';
 import { execSync } from 'child_process';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { inOperator } from './json';
+
+const selfPackage = JSON.parse(
+  readFileSync(join(__dirname, '../../package.json')).toString(),
+) as unknown;
+if (
+  !inOperator('version', selfPackage)
+) {
+  throw new Error("Can't detect version of @eternagame/nx-plugin");
+}
+const { version } = selfPackage;
+if (typeof version !== 'string') {
+  throw new Error("Can't detect version of @eternagame/nx-plugin");
+}
+export const NX_PLUGIN_VERSION = version;
 
 function testForDependencies(packageJson: unknown, dependencySection: string): string[] {
   if (!inOperator(dependencySection, packageJson)) return [];

--- a/packages/nx-plugin/src/utils/dependencies.ts
+++ b/packages/nx-plugin/src/utils/dependencies.ts
@@ -6,8 +6,10 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { inOperator } from './json';
 
+// Note that we have to go an extra level up because when built, this file will be in
+// dist/src/... not just dist/...
 const selfPackage = JSON.parse(
-  readFileSync(join(__dirname, '../../package.json')).toString(),
+  readFileSync(join(__dirname, '../../../package.json')).toString(),
 ) as unknown;
 if (
   !inOperator('version', selfPackage)


### PR DESCRIPTION
fix(nx-plugin): Fix publishing prompt message in preset generator 
fix(nx-plugin): Fix prompt license missing EternaNoncommercial license in preset generator
fix(nx-plugin): Remove invalid trailing comma in vscode settings.json template
fix(nx-plugin): Ensure lint-staged-utils is installed in preset generator
fix(nx-plugin): Ensure bootstrap process results in the version of nx-plugin being installed that is run for the preset generator
fix(bootstrap): Pass eterna parameter to preset generator
fix(nx-plugin): Don't generate root package.json with type module
fix(nx-plugin): Fix reading gitignore in .eslintrc.js template
fix(eslint-plugin): Allow cypress files to import from dev dependencies
fix(nx-plugin): Fix lint errors in generated cypress-ct files
fix(nx-plugin): Fix lint errors in generated vue files
chore(nx-plugin): Remove unused executors file
fix(eslint-plugin): Fix error where typescript-eslint can't associate Vue files with their tsconfig if there are ts/js files sorted alphabetically earlier (eg, ts files in the cypress folder)
fix(nx-plugin): Mark the lint task as only depending on dependencies being built, not the current package
docs(nx-plugin):  Update test command info