### PR TITLE
chore(repo): Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner
+*       @eternagame/Maintainers


### PR DESCRIPTION
This will let us adjust our branch protection rules to allow for non-maintainers with write access to self-merge