### PR TITLE
fix(nx-plugin): Remove CI config as implicit dependency

### DIFF
--- a/packages/nx-plugin/preset.json
+++ b/packages/nx-plugin/preset.json
@@ -6,7 +6,6 @@
   "implicitDependencies": {
     "package.json": "*",
     "package-lock.json": "*",
-    ".github/workflows/ci.yml": "*",
     "nx.json": "*"
   },
   "tasksRunnerOptions": {


### PR DESCRIPTION
Changing our Actions workflow won't affect the result of the outcome of any commands, so it should not be an implicit dependency (if there was something in it that should invalidate some target, the target inputs should be updated accordingly)