### PR TITLE
fix(nx-plugin): Fix package generation with empty copyright holder

### DIFF
--- a/packages/nx-plugin/src/generators/license/util/index.ts
+++ b/packages/nx-plugin/src/generators/license/util/index.ts
@@ -91,17 +91,24 @@ export function getLicenseDefaults(tree: Tree): LicenseOptions | null {
   if (!licenseDefaults) return null;
 
   const license = getValue(licenseDefaults, null, 'license');
-  const copyrightHolder = getValue(licenseDefaults, '', 'copyrightHolder');
+  const copyrightHolder = getValue(licenseDefaults, null, 'copyrightHolder');
   if (!license) {
     throw new Error('License property is required in generator defaults for license-package in nx.json');
   }
   if (typeof license !== 'string' || !isArrayMember(license, licenses)) {
     throw new Error(`License property in generator defaults for license-package in nx.json must be one of: [${licenses.join(',')}]`);
   }
+
+  // If not using a license or using a custom license, there's no reason to specify
+  // a copyright holder, so we can just return the license
+  if (license === 'None' || license === 'Custom') {
+    return { license };
+  }
+
   if (typeof copyrightHolder !== 'string') {
     throw new Error('Copyright holder property in defaults for license-package in nx.json must be a string');
   }
-  if (license !== 'None' && license !== 'Custom' && (!copyrightHolder)) {
+  if (!copyrightHolder) {
     throw new Error('Copyright holder property in defaults for license-package in nx.json must be specified');
   }
 

--- a/packages/nx-plugin/src/generators/license/util/index.ts
+++ b/packages/nx-plugin/src/generators/license/util/index.ts
@@ -91,7 +91,7 @@ export function getLicenseDefaults(tree: Tree): LicenseOptions | null {
   if (!licenseDefaults) return null;
 
   const license = getValue(licenseDefaults, null, 'license');
-  const copyrightHolder = getValue(licenseDefaults, null, 'copyrightHolder');
+  const copyrightHolder = getValue(licenseDefaults, '', 'copyrightHolder');
   if (!license) {
     throw new Error('License property is required in generator defaults for license-package in nx.json');
   }


### PR DESCRIPTION
When generating a repository and specifying not to include a license or using a custom license, the copyright holder field is not needed and will not be set. However, when generating a package, it was defaulted to null and is unconditionally checked to be a string. The new behavior properly allows it to be omitted in these situations.