### PR TITLE
fix(nx-plugin): Avoid CI failure when no release PR exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       releases_created:  ${{ steps.prep-release.outputs.releases_created }}
+      prs_exist: ${{ steps.prep-release.outputs.prs || 'false' }}
     steps:
       - name: Prep release
         id: prep-release
@@ -24,7 +25,7 @@ jobs:
     name: Update release PR with lockfile updates
     runs-on: ubuntu-latest
     needs: release-please
-    if: needs.release-please.outputs.releases_created != 'true'
+    if: needs.release-please.outputs.releases_created != 'true' && needs.release-please.outputs.prs_exist != 'false'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/packages/nx-plugin/src/generators/release/repo/files/.github/workflows/release.yml__tmpl__
+++ b/packages/nx-plugin/src/generators/release/repo/files/.github/workflows/release.yml__tmpl__
@@ -12,7 +12,8 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     outputs:
-      releases_created:  ${{ steps.prep-release.outputs.releases_created }}
+      releases_created:  ${{ steps.prep-release.outputs.releases_created  }}
+      prs_exist: ${{ steps.prep-release.outputs.prs || 'false' }}
     steps:
       - name: Prep release
         id: prep-release
@@ -24,7 +25,7 @@ jobs:
     name: Update release PR with lockfile updates
     runs-on: ubuntu-latest
     needs: release-please
-    if: needs.release-please.outputs.releases_created != 'true'
+    if: needs.release-please.outputs.releases_created != 'true' && needs.release-please.outputs.prs_exist != 'false'
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Currently, if a commit is pushed to main when the release PR branch does not exist and is not caused to be created (eg, when committing to a repo before any packages are configured), the CI still attempts to run lockfile updates on the release PR branch, as we always do it whenever a release is not created. This also prevents it from running when there is no active release PR (when a release PR exists, the release branch must also exist).

This was tested on a separate independent repo. Ensured the job ran when new commits are pushed to the release PR, but not when the release PR is not present or when merging the release PR