### PR TITLE
fix(nx-plugin): Adjust custom release PR title to account for release-please update

### DIFF
--- a/packages/nx-plugin/src/generators/release/repo/files/release-please-config.json
+++ b/packages/nx-plugin/src/generators/release/repo/files/release-please-config.json
@@ -3,8 +3,8 @@
   "plugins": [
     "node-workspace"
   ],
-  "pull-request-title-pattern": "chore(repo): Release latest on ${branch}",
   "group-pull-request-title-pattern": "chore(repo): Release latest on ${branch}",
+  "separate-pull-requests": false,
   "changelog-sections": [
     {
       "type": "feat",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,8 +3,8 @@
   "plugins": [
     "node-workspace"
   ],
-  "pull-request-title-pattern": "chore(repo): Release latest on ${branch}",
   "group-pull-request-title-pattern": "chore(repo): Release latest on ${branch}",
+  "separate-pull-requests": false,
   "changelog-sections": [
     {
       "type": "feat",


### PR DESCRIPTION
A recent update to release-please fixed the usage of `group-pull-request-title-pattern`, but introduced a regression with custom release titles when `separate-pull-requests` is unspecified (see https://github.com/googleapis/release-please/issues/1777)