### PR TITLE
fix(nx-plugin): Handle testing in watch mode

### DIFF
--- a/packages/nx-plugin/preset.json
+++ b/packages/nx-plugin/preset.json
@@ -50,8 +50,11 @@
       "outputs": ["./cypress-run", "./coverage"],
       "dependsOn": ["^build"]
     },
-    "test:ui": {
-      "dependsOn": ["^build"]
+    "test:_ui": {
+      "dependsOn": ["^build:watch"]
+    },
+    "test:_watch": {
+      "dependsOn": ["^build:watch"]
     },
     "e2e": {
       "inputs": ["default", "^default", "test"],

--- a/packages/nx-plugin/preset.json
+++ b/packages/nx-plugin/preset.json
@@ -51,8 +51,6 @@
       "dependsOn": ["^build"]
     },
     "test:ui": {
-      "inputs": ["default", "^default", "test"],
-      "outputs": ["./cypress-run"],
       "dependsOn": ["^build"]
     },
     "e2e": {

--- a/packages/nx-plugin/preset.json
+++ b/packages/nx-plugin/preset.json
@@ -50,6 +50,11 @@
       "outputs": ["./cypress-run", "./coverage"],
       "dependsOn": ["^build"]
     },
+    "test:ui": {
+      "inputs": ["default", "^default", "test"],
+      "outputs": ["./cypress-run"],
+      "dependsOn": ["^build"]
+    },
     "e2e": {
       "inputs": ["default", "^default", "test"],
       "outputs": ["./cypress-run"]

--- a/packages/nx-plugin/src/generators/package/cypress/ct/index.ts
+++ b/packages/nx-plugin/src/generators/package/cypress/ct/index.ts
@@ -49,7 +49,8 @@ function updatePackageJson(tree: Tree, options: NormalizedSchema) {
     if (!json['scripts']) json['scripts'] = {};
     const scripts = json['scripts'] as Record<string, string>;
     scripts['test'] = 'cypress run --component';
-    scripts['test:ui'] = 'cypress open --component';
+    scripts['test:ui'] = 'nx-spawn test:_ui';
+    scripts['test:_ui'] = 'cypress open --component';
     // TODO: Figure out cypress ct test coverage. Related: https://github.com/cypress-io/cypress/issues/16798
     delete scripts['test:cov'];
     // Cypress doesn't have a non-ui watch mode - see https://github.com/cypress-io/cypress/issues/3665

--- a/packages/nx-plugin/src/generators/package/ts/lib/index.ts
+++ b/packages/nx-plugin/src/generators/package/ts/lib/index.ts
@@ -48,7 +48,8 @@ function updatePackageJson(tree: Tree, options: NormalizedSchema) {
     scripts['build'] = 'vite build';
     scripts['build:watch'] = 'vite build --mode development';
     scripts['test'] = 'vitest run';
-    scripts['test:watch'] = 'vitest';
+    scripts['test:watch'] = 'nx-spawn test:_watch';
+    scripts['test:_watch'] = 'vitest';
     scripts['test:cov'] = 'vitest run --coverage';
     scripts['lint'] = 'eslint .';
 


### PR DESCRIPTION
<!--
    Thank you for submitting a pull request! We appreciate your time and effort.
    Please make sure you have read our contributing guidelines before posting a PR
    https://github.com/eternagame/.github/blob/main/CONTRIBUTING.md

    Please title your PR according to the conventional commits standard - see the contributing
    guidelines for more info. Additionally, help us review your changes and provide a record for
    later reference by providing the information below. Note that the PR description will be used
    as the commit description when the PR is merged, so please keep it up to date as you make any changes!
-->

## Summary
<!--
    What is the motivation for making this change? If applicable, how does this change affect the
    behavior of the application/library? What was the behavior before, and what is it now? If there
    were any trade-offs or possible alternative behaviors that you considered, what were they and why
    did you decide on this approach?

    Provide samples as appropriate. If there are visual changes, include screenshots or video!
-->
Currently, when running `test:watch` or `test:ui`, prerequisite tasks (ie, building dependencies) are not run. This adjusts both of these commands to be set up with nx spawn and adjusts the nx preset to spin up `build:watch` tasks for any dependencies.

## Implementation Notes
<!--
    Provide a high-level overview of these changes on a technical level. What was changed in the code?
    If there were any trade-offs or possible alternative implementations that you considered, what
    were they and why did you decide on this approach? Provide any additional context beyond what is
    recorded in the code (eg, comments) that could be useful if someone wants to understand what your
    code does and why it was done that way later.
-->
- The actual `test:watch` and `test:ui` commands do not have the build dependencies set - they're set on the command called by `nx-spawn` so that `nx-spawn` starts those, not `nx` itself
- `build:watch` for dependencies is the only prerequisite set of tasks.
- Caching is neither enabled nor configured for these test commands as it doesn't make sense to cache a watch task

## Testing
<!--
    How did you verify that this change works as intended? Automated tests? Comparing results when running
    an application? What scenarios did you consider when testing? If it is a user interface change, did you
    test it on a variety of screen sizes?
-->
Spun up two packages, one which is the dependency of the other. Making a change in the dependency while `test:watch` was run on the main package triggered it to be rebuilt. Note that the tests do not appear to be automatically rerun on dependency change - I tried adjusting the vitest configuration, but no combination of adjustments to the watchExclude or deps parameters changed this behavior. For now, the workaround is to just type `a` in the console to trigger a full rerun. Cypress may not have this limitation.
, 
