### PR TITLE
fix(nx-spawn): Task completion when a package has > 1 dep

### DIFF
--- a/packages/nx-spawn/src/promise-walker.ts
+++ b/packages/nx-spawn/src/promise-walker.ts
@@ -25,7 +25,7 @@ export default class PromiseWalker<T> {
         return { promise, result };
       }),
     );
-    this._promises.splice(this._promises.indexOf(wrapper.promise));
+    this._promises.splice(this._promises.indexOf(wrapper.promise), 1);
     return wrapper.result;
   }
 


### PR DESCRIPTION
## Summary
Previously, if package a relied on b and c, and nx-spawn initiated a task on package a that ran tasks on b and c, the task on b or c would complete, but the task on a would not be run. 

## Implementation Notes
The source of this issue was in `promise-walker`, which is responsible for keeping track of task completion promises and returning one completed task result at a time. Because the second argument (`deleteCount`) was never provided to `splice`, when there were multiple promises being waited on at once, when one resolved all were removed, preventing it from returning the result of the other promises.

## Testing
Created `testapp`, `testlib`, and `testwlib`, with the libs added as dependencies of the app, and ran `nx dev testapp`. Ensured an initial failure, then verified the fix resolved the issue.

## Related Issues
Resolves #210