### PR TITLE
fix(nx-plugin): Add build:watch of dependencies as explicit dependency of _dev

### DIFF
--- a/packages/nx-plugin/preset.json
+++ b/packages/nx-plugin/preset.json
@@ -71,7 +71,7 @@
       "outputs": ["{projectRoot}/dist"]
     },
     "_dev": {
-      "dependsOn": ["build:watch"]
+      "dependsOn": ["build:watch", "^build:watch"]
     },
     "start": {
       "dependsOn": ["build"]


### PR DESCRIPTION
## Summary
Previously, when running dev/_dev for a package which did not itself have a `build:watch` task (eg, a package generated with the web-app generator), its dependencies would not be built.

## Implementation Notes
I originally thought that Nx would wire up the task dependencies even if the script did not exist - this doesn't seem to be the case.

## Testing
Created a web-app and added a ts-lib dependency. Previously running dev on the app wouldn't run the dependency's watch task. It now does.
