### PR TITLE
fix(nx-spawn): Avoid starting watch tasks from stale build output

### DIFF
--- a/packages/nx-spawn/src/task-orchestrator.ts
+++ b/packages/nx-spawn/src/task-orchestrator.ts
@@ -230,35 +230,49 @@ export default class TaskOrchestrator {
     runner: ForkedProcessTaskRunner,
     projectGraph: ProjectGraph,
   ): Promise<StartedProcess> {
-    // Start the task
-    const process = runner.forkProcessPipeOutputCapture(task, {
+    const runTask = () => runner.forkProcessPipeOutputCapture(task, {
       temporaryOutputPath: this.temporaryOutputPath(task),
       streamOutput: true,
     });
 
-    // Spin up a chokidar watcher to notify us when the output files for the task are written
-    const node = projectGraph.nodes[task.target.project];
-    if (!node) throw new Error(`Can't find node for ${task.target.project}`);
-    // For some reason getOutputsForTargetAndConfiguration is typed as returning `any`
-    const outputs = getOutputsForTargetAndConfiguration(task, node) as string[];
-    const watcher = watch(outputs, {
-      cwd: workspaceRoot,
-      ignoreInitial: false,
-    });
+    let process: ReturnType<typeof runTask>;
 
     if (this.isLongRunningTask(task)) {
+      // Spin up a chokidar watcher to notify us when the output files for the task are written
+      const node = projectGraph.nodes[task.target.project];
+      if (!node) throw new Error(`Can't find node for ${task.target.project}`);
+      // For some reason getOutputsForTargetAndConfiguration is typed as returning `any`
+      const outputs = getOutputsForTargetAndConfiguration(task, node) as string[];
+      const watcher = watch(outputs, {
+        cwd: workspaceRoot,
+        // Note that even if the files were already written previously, we still wait for them to be
+        // re-written, as this ensures we're not continuing with stale output and avoids multiple
+        // executions from being triggered when eg vite builds a downstream package then this build
+        // completes and even if nothing changes it still re-writes the files, causing the
+        // downstream to build again
+        ignoreInitial: true,
+      });
+
       // Assuming the task has outputs, make sure the task has written the outputs at least once
       // before moving on and starting subsequent tasks
-      await Promise.all(
+      const ready = Promise.all(
         outputs.map(
           (f) => new Promise<void>((resolve) => {
             watcher.on('add', (path) => {
               if (path.startsWith(f)) resolve();
             });
+            watcher.on('change', (path) => {
+              if (path.startsWith(f)) resolve();
+            });
           }),
         ),
       );
+
+      process = runTask();
+      await ready;
+      await watcher.close();
     } else {
+      process = runTask();
       // Wait for the task to exit
       await process;
     }


### PR DESCRIPTION
## Summary
Consider a relies on b, and b has already been built before. When b is kicked off, it is immediately marked as "ready" since there are already some built files, but the watch task will be re-writing them, causing b to build twice. While this does theoretically allow for a faster startup time, it comes at the cost of confusing/noisy logs and potential problems with stale build output.

## Implementation Notes
We now start the chokidar watcher before running the task, enabling ignoreInitial and also supporting a file change event as indication we can continue (ie, in the case of a vite build:watch, we can continue when vite overwrites previously existing files in dist instead of only if it writes new files)

## Testing
Created an app a, which depends on lib b, which depends on lib c. Previously, if all had been previously built, all tasks would be started at the same time, and build output would be interleaved. Now, this situation has c finish its first build, then b finishes its first build, then a starts.

## Related Issues
Resolves #184 
