### PR TITLE
fix(eslint-plugin): Disable ts-eslint intent rule for parameter decorator

### DIFF
--- a/packages/eslint-plugin/src/configs/base/typescript.ts
+++ b/packages/eslint-plugin/src/configs/base/typescript.ts
@@ -1,3 +1,7 @@
+import base from 'eslint-config-airbnb-typescript/lib/shared';
+
+const [indentLevel, indentAmount, indentConfig] = base.rules['@typescript-eslint/indent'];
+
 export default {
   parserOptions: {
     project: ['tsconfig.*?.json', 'tsconfig.json'],
@@ -28,5 +32,17 @@ export default {
     // Similar deal as the above - the import plugin won't resolve our aliases properly, plus
     // tsc already places limitations on allowed extensions
     'import/extensions': 'off',
+    // See https://github.com/typescript-eslint/typescript-eslint/issues/1824
+    '@typescript-eslint/indent': [
+      indentLevel,
+      indentAmount,
+      {
+        ...indentConfig,
+        ignoredNodes: [
+          ...indentConfig.ignoredNodes,
+          'FunctionExpression[params]:has(Identifier[decorators])',
+        ],
+      },
+    ],
   },
 };

--- a/packages/eslint-plugin/src/shims.d.ts
+++ b/packages/eslint-plugin/src/shims.d.ts
@@ -24,6 +24,23 @@ interface AirBnbImportsConfig {
   };
 }
 
-declare module 'eslint-config-airbnb-typescript/lib/shared' {}
+interface AirBnbStyleConfig {
+  rules: {
+    '@typescript-eslint/indent': [
+      string,
+      number,
+      {
+        ignoredNodes: string[]
+      },
+    ]
+  }
+}
 
-declare module 'eslint-config-airbnb-base/rules/imports' {}
+declare module 'eslint-config-airbnb-typescript/lib/shared' {
+  type FullConfig = AirBnbImportsConfig & AirBnbStyleConfig;
+  export = {} as FullConfig;
+}
+
+declare module 'eslint-config-airbnb-base/rules/imports' {
+  export = {} as AirBnbImportsConfig;
+}


### PR DESCRIPTION
## Summary
This resolves the following issue
![image](https://user-images.githubusercontent.com/18635705/235740256-a42e8de5-d7c2-48da-9016-a57978015b8f.png)

## Implementation Notes
See https://github.com/typescript-eslint/typescript-eslint/issues/1824
